### PR TITLE
Fix sequence misspelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
             }
         ],
         "configuration": {
-            "title": "Sequance Diagram configuration",
+            "title": "Sequence Diagram configuration",
             "type": "object",
             "properties": {
                 "sequencediagrams.diagram.style": {


### PR DESCRIPTION
Fix for sequence misspelling. VSCode configuration GUI surfaces the misspelling.

![image](https://user-images.githubusercontent.com/1464385/59781396-8bbe2e80-9270-11e9-8494-e4b8c81744de.png)
