### PR TITLE
Restore tsconfig.json, fix out dir to `dist`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "dist",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "."
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
Think this should resolve the build issues referenced in #23 

Previous patch corrected dev/prod build differences between webpack and typescript, but I removed tsconfig.json, which was still required.  Think this should do it.

![image](https://user-images.githubusercontent.com/799130/104774771-406a4b80-5745-11eb-9d77-d1793945be14.png)
