### PR TITLE
fix: allow loading of resources from workspace root and extension's i…

### DIFF
--- a/src/previewContentProvider.ts
+++ b/src/previewContentProvider.ts
@@ -25,9 +25,12 @@ export default class previewContentProvider {
             vscode.ViewColumn.Two, {
                 enableScripts: true,
                 enableCommandUris: false,
-                localResourceRoots: [
-                    vscode.Uri.file(path.join(context.extensionPath, 'src'))
-                ]
+                // Root paths from which the webview can load local (filesystem) resources using uris from asWebviewUri
+                // Default to the root folders of the current workspace plus the extension's install directory.
+                // Pass in an empty array to disallow access to any local resources.
+                // localResourceRoots: [
+                //     vscode.Uri.file(path.join(context.extensionPath, 'src'))
+                // ]
             });
 
         // Handle messages from the webview


### PR DESCRIPTION
…nstall directory

Fixes #23

I'm not very familiar with developing VSCode extensions, but it seems like this is all that's needed to allow sequence diagrams to render again when built with `yarn vscode:prepublish`

![Screen Shot 2021-03-11 at 9.13.35 AM.png](https://user-images.githubusercontent.com/18055194/110803240-fdac8780-824c-11eb-901e-d1e2c6c346f6.png)