### PR TITLE
Fix assetPath function for production package

### DIFF
--- a/src/previewContentProvider.ts
+++ b/src/previewContentProvider.ts
@@ -26,7 +26,7 @@ export default class previewContentProvider {
                 enableScripts: true,
                 enableCommandUris: false,
                 localResourceRoots: [
-                    vscode.Uri.file(path.join(context.extensionPath, 'src'))
+                    vscode.Uri.joinPath(context.extensionUri, 'dist')
                 ]
             });
 
@@ -179,7 +179,7 @@ export default class previewContentProvider {
     private assetPath(resourcePath) {
         return this.currentPanel.webview.asWebviewUri(
             vscode.Uri.file(
-                path.join(this.extensionPath, 'src', resourcePath)
+                path.join(this.extensionPath, 'dist', resourcePath)
             )
         )
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
             "es6"
         ],
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": "src"
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Found the issue, as well as the source of the debugging problem.

**Issue**
The asset path function was creating the wrong path for assets as packaged up for distribution.  It was building for `./src` when the package was only being distributed with extension assets in `./dist`.  This was complicated by the fact that the src path worked when debugging the extension from source.

**Debugging Problem**
To validate this, I needed to package the extension locally and install it to validate fixes.  To create the package locally, simply run `vsce package`.  This will drop the packaged extension `vscode-sequence-diagrams-0.4.4.vsix` locally, which you can right click on and install.

![image](https://user-images.githubusercontent.com/799130/113157474-ea1b8d80-9208-11eb-97a2-05fd2419946d.png)

Next time you open a diagram, open webview developer tools (Command Palette: Open Webview Developer Tools) and refresh the Network tab.  You should see your extension pulling from your build package (_not_ your developer source).

![image](https://user-images.githubusercontent.com/799130/113157848-3e267200-9209-11eb-94d7-6bbd00baeb9f.png)

Based on this, I'm confident this should be fixed up.  Phew!